### PR TITLE
Prepare 0.1.0 release workflow

### DIFF
--- a/.github/workflows/dotnet-tool.yml
+++ b/.github/workflows/dotnet-tool.yml
@@ -61,7 +61,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2.8.2
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Install Linux ARM64 linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -81,6 +81,13 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: |
           cargo build --locked --release -p psign --bin psign-tool --target "${{ matrix.target }}"
+
+      - name: Verify Windows version info
+        if: contains(matrix.target, 'windows-msvc')
+        shell: pwsh
+        run: |
+          ./scripts/ci/test-windows-version-info.ps1 `
+            -Path "target/${{ matrix.target }}/release/${{ matrix.binary }}"
 
       - name: Package artifact
         shell: pwsh
@@ -157,6 +164,16 @@ jobs:
             -ArtifactsRoot "dist" `
             -StagingRoot $stagingRoot `
             -OutputDir "dist/nuget"
+
+      - name: Smoke-test dotnet tool package install
+        shell: pwsh
+        env:
+          CI_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          ./nuget/scripts/Test-PsignDotnetToolPackage.ps1 `
+            -Version "0.0.0-ci.$env:CI_RUN_NUMBER" `
+            -PackageDir "dist/nuget" `
+            -ToolPath (Join-Path $env:RUNNER_TEMP "psign-tool-package-smoke")
 
       - name: Upload dry-run dotnet tool artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,15 @@ on:
         required: false
         default: false
         type: boolean
+      github-env:
+        description: GitHub environment selection
+        required: false
+        type: choice
+        options:
+          - auto
+          - test
+          - prod
+        default: auto
       dry_run_nuget:
         description: Dry-run NuGet publish and GitHub release asset upload
         required: false
@@ -83,11 +92,34 @@ jobs:
 
           $releaseTag = "v$releaseVersion"
           $isMasterBranch = $sourceBranch -eq 'master'
-          $publishEnv = if ($isMasterBranch) { 'publish-prod' } else { 'publish-test' }
           $publishNuget = Parse-BoolOrDefault '${{ github.event.inputs.publish_nuget }}' $false
           $dryRun = Parse-BoolOrDefault '${{ github.event.inputs.dry_run_nuget }}' $true
+          $requestedEnvironment = '${{ inputs['github-env'] }}'.Trim().ToLowerInvariant()
+          if ([string]::IsNullOrWhiteSpace($requestedEnvironment)) {
+            $requestedEnvironment = 'auto'
+          }
 
-          if (-not $isMasterBranch) {
+          switch ($requestedEnvironment) {
+            'auto' {
+              $publishEnv = if ($isMasterBranch) { 'publish-prod' } else { 'publish-test' }
+            }
+            'test' {
+              $publishEnv = 'publish-test'
+            }
+            'prod' {
+              $publishEnv = 'publish-prod'
+            }
+            default {
+              throw "Unsupported github-env value: $requestedEnvironment (expected auto, test, or prod)."
+            }
+          }
+
+          if ($requestedEnvironment -eq 'test' -and ($isMasterBranch -or ((-not $dryRun) -and $publishNuget))) {
+            $publishEnv = 'publish-prod'
+            Write-Host '::notice::github-env=test was promoted to publish-prod'
+          }
+
+          if ((-not $isMasterBranch) -and $publishEnv -ne 'publish-prod') {
             $dryRun = $true
           }
 
@@ -104,6 +136,7 @@ jobs:
           Write-Host "::notice::Release tag: $releaseTag"
           Write-Host "::notice::Build ref: $buildRef"
           Write-Host "::notice::Source branch: $sourceBranch"
+          Write-Host "::notice::GitHub environment mode: $requestedEnvironment"
           Write-Host "::notice::Publish environment: $publishEnv"
           Write-Host "::notice::Publish NuGet: $($publishNuget.ToString().ToLowerInvariant())"
           Write-Host "::notice::NuGet dry-run: $($dryRun.ToString().ToLowerInvariant())"
@@ -165,7 +198,7 @@ jobs:
           rustup default stable
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2.8.2
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Install Linux ARM64 linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -185,6 +218,17 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: |
           cargo build --locked --release -p psign --bin psign-tool --target "${{ matrix.target }}"
+
+      - name: Verify Windows version info
+        if: contains(matrix.target, 'windows-msvc')
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+        run: |
+          $version = $env:RELEASE_TAG.TrimStart('v')
+          ./scripts/ci/test-windows-version-info.ps1 `
+            -Path "target/${{ matrix.target }}/release/${{ matrix.binary }}" `
+            -ExpectedVersion $version
 
       - name: Package artifact
         if: ${{ !contains(matrix.target, 'windows-msvc') }}
@@ -415,6 +459,21 @@ jobs:
             -ArtifactsRoot "dist" `
             -StagingRoot $stagingRoot `
             -OutputDir "dist/nuget"
+
+      - name: Smoke-test dotnet tool package install
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+        run: |
+          $tag = $env:RELEASE_TAG
+          if (-not $tag.StartsWith('v')) {
+            throw "Release tag must start with 'v'. Actual: $tag"
+          }
+
+          ./nuget/scripts/Test-PsignDotnetToolPackage.ps1 `
+            -Version $tag.Substring(1) `
+            -PackageDir "dist/nuget" `
+            -ToolPath (Join-Path $env:RUNNER_TEMP "psign-tool-package-smoke")
 
       - name: Upload dotnet tool artifact
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This repository is a **Rust port** of the Windows SDK **`signtool.exe`** (Authenticode sign / verify / timestamp / remove, plus related flows). Portable digest logic mirrors inbox SIP hashing where implemented; the full CLI depends on Win32 (**`WinVerifyTrust`**, **`SignerSignEx3`**, CryptSIP).
 
+Canonical repository: <https://github.com/Devolutions/psign>.
+
 ## Workspace layout
 
 | Area | Path | Notes |
@@ -9,11 +11,15 @@ This repository is a **Rust port** of the Windows SDK **`signtool.exe`** (Authen
 | Root package (unified CLI + lib) | `Cargo.toml` (package **`psign`**) | **`psign-tool`** dispatches to Win32 code on Windows or portable Rust paths via `--mode`; **`windows`** crate feature deps stay under **`cfg(windows)`**. |
 | Portable digest library | `crates/psign-sip-digest` | No **`windows`** dependency; Linux-safe unit tests. |
 | Portable Authenticode trust | `crates/psign-authenticode-trust` | Anchors + picky chain; **`psign-tool portable`** **`trust-verify-pe`**, **`trust-verify-cab`**, **`trust-verify-catalog`**, **`trust-verify-detached`** — no OS trust store. |
-| Portable CLI runner | `crates/psign-digest-cli` | Library used by **`psign-tool portable ...`**; no separate portable executable is emitted. |
+| Portable CLI runner | `crates/psign-digest-cli` | Library used by **`psign-tool portable ...`**; feature-gates REST and timestamp HTTP helpers; no separate portable executable is emitted. |
+| Portable package primitives | `crates/psign-opc-sign` | OPC / VSIX / NuGet marker inspection and NuGet package digest primitives used by portable package helpers. |
+| Azure Code Signing REST | `crates/psign-codesigning-rest` | Portable blocking client for Artifact Signing / Trusted Signing data-plane hash-sign LROs. |
+| Azure Key Vault REST | `crates/psign-azure-kv-rest` | Portable blocking client for Key Vault certificate metadata and `keys/sign`. |
 | Win32 implementation | `src/win/` | Verify, sign, timestamp, catalog, detached PKCS#7, etc. |
 | argv / response files | `src/native_argv.rs`, `src/response_argv.rs` | Shared by unified CLI and portable-mode builds. |
+| CI / parity scripts | `scripts/`, `.github/workflows/` | Windows parity harnesses, Unix portable validation, corpus builders, and dependency graph generation. |
 
-**Important:** **`default-members`** include the root **`psign`** package plus the portable crates under **`crates/`**. A bare **`cargo build`** at the repo root builds the unified **`psign-tool`** executable from **`src/main.rs`**; portable functionality is invoked through **`psign-tool portable ...`**.
+**Important:** **`default-members`** include the root **`psign`** package plus all workspace crates under **`crates/`**. A bare **`cargo build`** at the repo root builds the unified **`psign-tool`** executable from **`src/main.rs`**; portable functionality is invoked through **`psign-tool portable ...`**.
 
 ## Commands agents should run
 
@@ -25,7 +31,7 @@ cargo clippy --workspace --all-targets --locked
 cargo test --workspace --locked
 ```
 
-On Linux/macOS, match **`ci-unix`**: fmt check, metadata **`--locked`**, clippy **`-D warnings`** on **`psign-sip-digest`**, **`psign-digest-cli`**, **`psign-authenticode-trust`**, **`psign --lib`**, then **`cargo test -p psign-sip-digest --lib`**, **`cargo test -p psign-authenticode-trust --lib`**, **`cargo test -p psign --test cli_pe_digest`**, and **`cargo test -p psign --lib`**.
+On Linux/macOS, match **`ci-unix`** by running **`bash scripts/linux-portable-validation.sh`**. It covers fmt check, metadata **`--locked`**, strict clippy for portable crates and feature combinations (**`artifact-signing-rest`**, **`azure-kv-sign-portable`**, **`timestamp-http`**), REST crate tests, **`cli_pe_digest`**, and **`psign --lib`**.
 
 **Windows-only parity** (when changing verify/sign/timestamp behavior): build **`psign`** and run **`scripts/run-parity-diff.ps1`** or **`scripts/ci/run-exhaustive-parity-ci.ps1`** with env vars described in **`docs/ci-parity.md`**.
 
@@ -38,10 +44,15 @@ On Linux/macOS, match **`ci-unix`**: fmt check, metadata **`--locked`**, clippy 
 | **`docs/rust-sip-gaps.md`** | Known limitations (MSIX sign gap, `/ph`, PKCS#7 encode, VBA, encrypted MSIX, …). |
 | **`docs/rust-sip-spec-refs.md`** | Spec links + PE page-hash / **`SignerSignEx3`** notes. |
 | **`docs/ci-parity.md`** | CI steps, **`PSIGN_*`** env vars, parity gates. |
+| **`docs/gap-analysis-signing-platforms.md`** | Current feature gaps vs native **`signtool`**, AzureSignTool, and Azure Artifact Signing. |
+| **`docs/linux-signing-pipelines.md`** | Linux / portable verify, REST hash-sign, and hybrid embed workflows. |
+| **`docs/migration-azuresigntool.md`** | Migration notes for AzureSignTool-style Key Vault signing. |
+| **`docs/migration-artifact-signing.md`** | Migration notes for Azure Artifact Signing / Trusted Signing. |
 | **`docs/roadmap-authenticode-linux.md`** | Unix/portable subset and **`psign-tool portable`**. |
 | **`docs/authenticode-trust-stack.md`** | Portable trust crate split (picky vs digest vs CMS). |
 | **`docs/authroot-linux-verify.md`** | Anchor dir + AuthRoot CAB usage on Linux. |
 | **`docs/plan-linux-authenticode-trust-verify.md`** | Technical plan (CTL, test matrix, risks). |
+| **`docs/psa-interoperability.md`** | Interop notes for PowerShell OpenAuthenticode and portable CMS behavior. |
 | **`docs/psign-cli-matrix.json`** | Machine-checked native ↔ Rust CLI mapping (with **`psign-cli-matrix.md`** summary). |
 
 Do **not** commit **`parity-output/`** or **`reversing/`** — they are **gitignored** (local parity JSON, **`psign-depgraph`** output, optional vendor DLL copies).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,7 @@ dependencies = [
  "tempfile",
  "uuid",
  "windows",
+ "winresource",
  "x509-cert",
  "zip",
 ]
@@ -2700,6 +2701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,6 +3088,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3619,6 +3668,22 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml",
+ "version_check",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ tempfile = "3"
 x509-cert = { version = "0.2.5", features = ["builder"] }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
+[build-dependencies]
+winresource = "0.1.31"
+
 [[bin]]
 name = "psign-tool"
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 (sign, verify, timestamp, remove, and related Authenticode flows), validated with
 differential parity tests against the native tool where CI fixtures allow.
 
-## Current command coverage
+Canonical repository: <https://github.com/Devolutions/psign>.
 
-- `verify`: WinVerifyTrust-backed implementation with policy modes (`default`, `pa`, `pg`).
+## CLI surface
+
+- `verify`, `remove`, `catdb`: Windows-compatible `signtool.exe` flows backed by WinTrust and CryptSIP where native APIs are required.
 - `sign`: Rust mssign32 core (`SignerSignEx3`) with PFX/system-store cert selection, RFC3161 sign-time timestamping, and decoupled-digest bridge flow (`--dlib` or `--trusted-signing-dlib-root` + `--dmdf`) for MSIX parity and [Azure Artifact Signing / Trusted Signing](docs/migration-artifact-signing.md).
 - `inspect-signature`: JSON dump of PKCS#7 signers, timestamp OIDs, and nested signatures (`1.3.6.1.4.1.311.2.4.1`) — same parser as **`psign-tool portable inspect-authenticode`** ([docs/psa-interoperability.md](docs/psa-interoperability.md)).
 - `timestamp`: Rust mssign32 core (`SignerTimeStampEx3`/`SignerTimeStampEx2`) plus AppX restrictions.
 - `rdp`: Rust port of **`rdpsign.exe`** for `.rdp` files (`SignScope` / `Signature` records, detached PKCS#7 over the secure-settings blob).
+- `cert-store`: Portable file-backed certificate store under `~/.psign/cert-store` by default, with Windows-style store/thumbprint selection.
+- `portable ...`: Cross-platform digest, verification, trust, signing, package, RFC3161, and remote-hash helpers that avoid Win32 APIs.
 
 ## MSIX parity notes
 
@@ -24,7 +28,7 @@ differential parity tests against the native tool where CI fixtures allow.
 cargo build
 ```
 
-At the repo root, **`cargo build`** targets **`default-members`**, including the unified **`psign-tool`** executable from `src\main.rs` plus the portable digest / trust / package crates. On Windows, **`cargo build -p psign --bin psign-tool`** remains the explicit way to build only that executable. Optional Cargo features: **`azure-kv-sign`** (Key Vault digest callback), **`artifact-signing-rest`** (**`artifact-signing-submit`** LRO against **`*.codesigning.azure.net`**).
+At the repo root, **`cargo build`** targets **`default-members`**, including the unified **`psign-tool`** executable from `src\main.rs` plus the portable digest / trust / package / REST crates. On Windows, **`cargo build -p psign --bin psign-tool`** remains the explicit way to build only that executable. Optional Cargo features: **`azure-kv-sign`** (Key Vault digest callback), **`artifact-signing-rest`** (**`artifact-signing-submit`** LRO against **`*.codesigning.azure.net`**), **`timestamp-http`** (portable RFC3161 HTTP POST), and **`timestamp-server`** (local RFC3161 test server).
 
 ## Dotnet tool package (.NET 10+)
 
@@ -50,9 +54,9 @@ pwsh ./nuget/pack-psign-dotnet-tool.ps1 -Version 0.1.0 -ArtifactsRoot ./dist -Ou
 
 The package is built from native `psign-tool` artifacts for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`, plus an `any` fallback package for unsupported runtimes.
 
-## Linux / portable digest tooling
+## Linux / portable tooling
 
-The canonical **`psign-tool`** CLI (package **`psign`**) supports an optional backend selector: **`--mode auto|windows|portable`**. When omitted, **`auto`** is used; **`PSIGN_TOOL_MODE`** can set the same default for parity automation. Windows mode uses Win32 APIs and registered SIP DLLs. Portable mode and the **`psign-tool portable ...`** namespace use the cross-platform Rust implementations from **`psign-sip-digest`**, **`psign-authenticode-trust`**, and **`psign-opc-sign`** without **`WinVerifyTrust`**.
+The canonical **`psign-tool`** CLI (package **`psign`**) supports an optional backend selector: **`--mode auto|windows|portable`**. When omitted, **`auto`** is used; **`PSIGN_TOOL_MODE`** can set the same default for parity automation. Windows mode uses Win32 APIs and registered SIP DLLs. Portable mode and the **`psign-tool portable ...`** namespace use the cross-platform Rust implementations from **`psign-sip-digest`**, **`psign-authenticode-trust`**, **`psign-opc-sign`**, **`psign-codesigning-rest`**, and **`psign-azure-kv-rest`** without **`WinVerifyTrust`** or the OS trust store.
 
 **Feature gaps vs native `signtool`, AzureSignTool, and Azure Artifact Signing:** [`docs/gap-analysis-signing-platforms.md`](docs/gap-analysis-signing-platforms.md). **Linux workflows (verify, REST hash sign, hybrid embed):** [`docs/linux-signing-pipelines.md`](docs/linux-signing-pipelines.md). For Key Vault **`RS256`** over CMS authenticated attributes (not the PE image hash), use **`psign-tool portable pe-signer-rs256-prehash`** — see [`docs/migration-azuresigntool.md`](docs/migration-azuresigntool.md).
 
@@ -64,6 +68,8 @@ cargo build -p psign --bin psign-tool --locked
 # psign-tool portable rdp --cert cert.der --key key.pk8 file.rdp
 # Portable PE signing with a local RSA key:
 # psign-tool portable sign-pe --cert cert.der --key key.pk8 --output signed.exe unsigned.exe
+# Portable trust verification with explicit anchors:
+# psign-tool portable trust-verify-pe signed.exe --anchor-dir anchors
 # Portable unsigned CAB signing with a local RSA key:
 # psign-tool portable sign-cab --cert cert.der --key key.pk8 --output signed.cab unsigned.cab
 # Portable MSI/MSP signing with a local RSA key:
@@ -79,11 +85,11 @@ cargo build -p psign --bin psign-tool --locked
 # Optional portable REST helpers (Linux/macOS):
 # cargo build -p psign --bin psign-tool --locked --features artifact-signing-rest
 # cargo build -p psign --bin psign-tool --locked --features azure-kv-sign
-cargo test -p psign-sip-digest -p psign-authenticode-trust -p psign-codesigning-rest -p psign-azure-kv-rest -p psign-digest-cli -p psign --locked
-cargo check -p psign-sip-digest -p psign-digest-cli -p psign-authenticode-trust -p psign-codesigning-rest -p psign-azure-kv-rest --locked
+cargo test -p psign-sip-digest -p psign-authenticode-trust -p psign-opc-sign -p psign-codesigning-rest -p psign-azure-kv-rest -p psign-digest-cli -p psign --locked
+cargo check -p psign-sip-digest -p psign-digest-cli -p psign-authenticode-trust -p psign-opc-sign -p psign-codesigning-rest -p psign-azure-kv-rest --locked
 ```
 
-Unix CI (`ci-unix`) runs **`cargo fmt`**, strict **`clippy -D warnings`** on those crates plus the **`psign` library**, and the digest CLI tests. Local mirror (bash): **`scripts/linux-portable-validation.sh`** from the repo root.
+Unix CI (`ci-unix`) runs **`cargo fmt`**, strict **`clippy -D warnings`** on portable / REST crates plus the **`psign` library**, and the digest CLI tests. Local mirror (bash): **`scripts/linux-portable-validation.sh`** from the repo root.
 
 ## Portable certificate store
 
@@ -153,7 +159,9 @@ Writes **`parity-output/vendor-binaries/`** (WOW64 under **`syswow64/`**): inbox
 ## Run tests
 
 ```powershell
-cargo test --workspace
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked
+cargo test --workspace --locked
 cargo test --test parity_signtool -- --ignored --nocapture
 ./scripts/run-parity-diff.ps1 -FailOnSemantic
 ```

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    let mut resource = winresource::WindowsResource::new();
+    resource
+        .set("CompanyName", "Devolutions")
+        .set(
+            "FileDescription",
+            "psign-tool Authenticode signing and verification tool",
+        )
+        .set("InternalName", "psign-tool")
+        .set("OriginalFilename", "psign-tool.exe")
+        .set("ProductName", "psign")
+        .set("LegalCopyright", "Copyright (c) Devolutions")
+        .set("Comments", "https://github.com/Devolutions/psign");
+
+    resource
+        .compile()
+        .expect("compile Windows version resource");
+}

--- a/nuget/scripts/Test-PsignDotnetToolPackage.ps1
+++ b/nuget/scripts/Test-PsignDotnetToolPackage.ps1
@@ -1,0 +1,60 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [string]$PackageDir = (Join-Path $PSScriptRoot "..\..\dist\nuget"),
+    [string]$ToolPath = (Join-Path ([System.IO.Path]::GetTempPath()) "psign-tool-package-smoke")
+)
+
+$ErrorActionPreference = "Stop"
+
+$packageSource = (Resolve-Path -LiteralPath $PackageDir).Path
+$nugetConfig = Join-Path ([System.IO.Path]::GetTempPath()) "psign-tool-package-smoke.nuget.config"
+
+if (Test-Path -LiteralPath $ToolPath) {
+    Remove-Item -LiteralPath $ToolPath -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $ToolPath | Out-Null
+
+@"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$packageSource" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -LiteralPath $nugetConfig -Encoding utf8
+
+try {
+    dotnet tool install Devolutions.Psign.Tool `
+        --tool-path $ToolPath `
+        --configfile $nugetConfig `
+        --version $Version
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet tool install failed with exit code $LASTEXITCODE"
+    }
+
+    $toolExe = @("psign-tool", "psign-tool.exe", "psign-tool.cmd") |
+        ForEach-Object { Join-Path $ToolPath $_ } |
+        Where-Object { Test-Path -LiteralPath $_ } |
+        Select-Object -First 1
+
+    if (-not $toolExe) {
+        throw "Installed tool shim not found under: $ToolPath"
+    }
+
+    & $toolExe --version
+    if ($LASTEXITCODE -ne 0) {
+        throw "psign-tool --version failed with exit code $LASTEXITCODE"
+    }
+
+    & $toolExe --help | Select-Object -First 12
+    if ($LASTEXITCODE -ne 0) {
+        throw "psign-tool --help failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $nugetConfig -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/ci/build-code-signing-vector-corpus.ps1
+++ b/scripts/ci/build-code-signing-vector-corpus.ps1
@@ -50,6 +50,21 @@ function Convert-ToManifestPath {
     return $Path
 }
 
+function Convert-ToManifestMessage {
+    param([string]$Message)
+    if (-not $Message) { return $Message }
+
+    $normalized = $Message
+    foreach ($path in @($SignedDir, $UnsignedDir, $WorkspaceRoot)) {
+        if (-not $path) { continue }
+        $absolute = (Resolve-Path -LiteralPath $path).Path
+        $relative = Convert-ToManifestPath -Path (Resolve-Path -LiteralPath $absolute -Relative)
+        if ($relative -eq "") { $relative = "." }
+        $normalized = $normalized.Replace($absolute, $relative)
+    }
+    return $normalized
+}
+
 if (-not $SignToolPath) {
     $SignToolPath = Resolve-File -Name "signtool.exe" -Candidates @(
         (Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"),
@@ -111,7 +126,7 @@ function Add-ReportEntry {
         $entry.size_bytes = $file.Length
         $entry.sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $file.FullName).Hash.ToLowerInvariant()
     }
-    if ($Message) { $entry.message = $Message }
+    if ($Message) { $entry.message = Convert-ToManifestMessage -Message $Message }
     $List.Add($entry)
 }
 

--- a/scripts/ci/test-windows-version-info.ps1
+++ b/scripts/ci/test-windows-version-info.ps1
@@ -1,0 +1,50 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [string]$ExpectedVersion = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $Path)) {
+    throw "Executable not found: $Path"
+}
+
+if ([string]::IsNullOrWhiteSpace($ExpectedVersion)) {
+    $metadataJson = cargo metadata --no-deps --format-version 1
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo metadata failed with exit code $LASTEXITCODE"
+    }
+
+    $metadata = $metadataJson | ConvertFrom-Json
+    $package = $metadata.packages | Where-Object { $_.name -eq "psign" } | Select-Object -First 1
+    if (-not $package) {
+        throw "Unable to resolve psign package version from cargo metadata."
+    }
+
+    $ExpectedVersion = [string]$package.version
+}
+
+$versionInfo = (Get-Item -LiteralPath $Path).VersionInfo
+
+$expected = [ordered]@{
+    FileVersion = $ExpectedVersion
+    ProductVersion = $ExpectedVersion
+    CompanyName = "Devolutions"
+    FileDescription = "psign-tool Authenticode signing and verification tool"
+    ProductName = "psign"
+    OriginalFilename = "psign-tool.exe"
+    InternalName = "psign-tool"
+    LegalCopyright = "Copyright (c) Devolutions"
+    Comments = "https://github.com/Devolutions/psign"
+}
+
+foreach ($name in $expected.Keys) {
+    $actual = [string]$versionInfo.$name
+    if ($actual -ne $expected[$name]) {
+        throw "Unexpected VERSIONINFO '$name' for '$Path': actual '$actual', expected '$($expected[$name])'."
+    }
+}
+
+Write-Host "Verified Windows VERSIONINFO for $Path"

--- a/tests/fixtures/generated-signed/generated-signed-vectors.json
+++ b/tests/fixtures/generated-signed/generated-signed-vectors.json
@@ -1178,7 +1178,7 @@
       "path": "tests\\fixtures\\generated-signed\\installer\\tiny-transform.mst",
       "size_bytes": 20480,
       "sha256": "3626d3f91744496841ec2fb12d2c485c6a4595485292185d07892082c2312a43",
-      "message": "File: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\installer\\tiny-transform.mst\nIndex  Algorithm  Timestamp    \n========================================\n\nSignTool Error: WinVerifyTrust returned error: 0x80096010\nNumber of errors: 1\n\n\n\tThe digital signature of the object did not verify.\n"
+      "message": "File: tests\\fixtures\\generated-signed\\installer\\tiny-transform.mst\nIndex  Algorithm  Timestamp    \n========================================\n\nSignTool Error: WinVerifyTrust returned error: 0x80096010\nNumber of errors: 1\n\n\n\tThe digital signature of the object did not verify.\n"
     },
     {
       "id": "generated-catalog-member-sys",
@@ -1256,7 +1256,7 @@
       "extension": ".p7x",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\p7x\\sample.p7x",
-      "message": "Done Adding Additional Store\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\p7x\\sample.p7x\n\nNumber of errors: 1\n"
+      "message": "Done Adding Additional Store\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\p7x\\sample.p7x\n\nNumber of errors: 1\n"
     },
     {
       "id": "generated-appinstaller-sample",
@@ -1264,7 +1264,7 @@
       "extension": ".appinstaller",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\appinstaller\\sample.appinstaller",
-      "message": "Done Adding Additional Store\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\appinstaller\\sample.appinstaller\n\nNumber of errors: 1\n"
+      "message": "Done Adding Additional Store\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\appinstaller\\sample.appinstaller\n\nNumber of errors: 1\n"
     },
     {
       "id": "generated-optional-provider-vsix",
@@ -1272,7 +1272,7 @@
       "extension": ".vsix",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.vsix",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.vsix\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.vsix\n"
     },
     {
       "id": "generated-optional-provider-vsto",
@@ -1280,7 +1280,7 @@
       "extension": ".vsto",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.vsto",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.vsto\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.vsto\n"
     },
     {
       "id": "generated-optional-provider-application",
@@ -1288,7 +1288,7 @@
       "extension": ".application",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.application",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.application\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.application\n"
     },
     {
       "id": "generated-optional-provider-deploy",
@@ -1296,7 +1296,7 @@
       "extension": ".deploy",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.deploy",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.deploy\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.deploy\n"
     },
     {
       "id": "generated-optional-provider-manifest",
@@ -1304,7 +1304,7 @@
       "extension": ".manifest",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.manifest",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.manifest\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.manifest\n"
     },
     {
       "id": "generated-optional-provider-docm",
@@ -1312,7 +1312,7 @@
       "extension": ".docm",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.docm",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.docm\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.docm\n"
     },
     {
       "id": "generated-optional-provider-xlsm",
@@ -1320,7 +1320,7 @@
       "extension": ".xlsm",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.xlsm",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.xlsm\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.xlsm\n"
     },
     {
       "id": "generated-optional-provider-pptm",
@@ -1328,7 +1328,7 @@
       "extension": ".pptm",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.pptm",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.pptm\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.pptm\n"
     },
     {
       "id": "generated-optional-provider-xlam",
@@ -1336,7 +1336,7 @@
       "extension": ".xlam",
       "state": "native-sign-rejected",
       "source_path": "tests\\fixtures\\generated-unsigned\\optional-provider\\probe.xlam",
-      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: C:\\Users\\mamoreau\\.copilot\\copilot-worktrees\\psign\\mamoreau-devolutions-reimagined-umbrella\\tests\\fixtures\\generated-signed\\optional-provider\\probe.xlam\n"
+      "message": "Done Adding Additional Store\n\nNumber of errors: 1\n\nSignTool Error: This file format cannot be signed because it is not recognized.\nSignTool Error: An error occurred while attempting to sign: tests\\fixtures\\generated-signed\\optional-provider\\probe.xlam\n"
     }
   ],
   "failed": []


### PR DESCRIPTION
Refresh release documentation and fixture metadata, add Windows VERSIONINFO embedding for psign-tool.exe, update release workflows for environment selection, Node 24-compatible rust-cache, package smoke tests, and Windows version metadata checks.