### PR TITLE
Add local Azure signing test services

### DIFF
--- a/crates/psign-digest-cli/src/main.rs
+++ b/crates/psign-digest-cli/src/main.rs
@@ -1086,6 +1086,9 @@ struct ArtifactSigningSubmitPortableArgs {
     client_secret: Option<String>,
     #[arg(long)]
     authority: Option<String>,
+    /// Override data-plane origin for deterministic local tests.
+    #[arg(long, hide = true)]
+    endpoint_base_url: Option<String>,
 }
 
 #[cfg(feature = "artifact-signing-rest")]
@@ -1180,7 +1183,7 @@ fn run_portable_artifact_signing_submit(args: ArtifactSigningSubmitPortableArgs)
         correlation_id: args.correlation_id,
         authority: args.authority,
         auth,
-        endpoint_base_url: None,
+        endpoint_base_url: args.endpoint_base_url,
     };
     let debug_portable = std::env::var_os("SIGNTOOL_PORTABLE_DEBUG").is_some();
     let v = submit_codesign_hash_blocking(&params, |msg| {

--- a/docs/ci-parity.md
+++ b/docs/ci-parity.md
@@ -34,6 +34,13 @@ For a local Windows timestamp parity run, use [`scripts/run-local-timestamp-pari
 
 For local no-admin online certificate checks, use [`scripts/run-local-online-cert-parity.ps1`](../scripts/run-local-online-cert-parity.ps1). It builds **`psign-server`** with timestamp HTTP support and runs the feature-gated loopback PKI tests for explicit **`--trusted-ca`** anchors, AIA, CRL, OCSP, and trusted RFC3161 timestamp validation. These tests intentionally exercise the portable trust backend because Windows **`WinVerifyTrust`** custom-root parity still requires either persistent user/machine store changes or deeper custom chain-policy integration.
 
+`psign-server` also provides local Azure-shaped endpoints for CI-safe signing tests:
+
+- **`azure-key-vault-server`** serves Key Vault-compatible certificate metadata and **`keys/sign`** responses. Automated coverage uses **`psign-tool portable azure-key-vault-sign-digest`** with a local bearer token and does not call Azure.
+- **`artifact-signing-server`** serves the Azure Code Signing / Trusted Signing **`:sign`** data-plane plus pollable LRO responses. Automated coverage uses both **`psign-tool portable artifact-signing-submit`** and the Windows **`psign-tool artifact-signing-submit`** command through the hidden local endpoint override.
+
+Full Windows PE signing through the Azure Key Vault **`SignerSignEx3`** callback still requires a local provider binding before it can be enabled as a non-ignored CI test; the local server already covers the REST digest-signing contract used by that path.
+
 For a **baseline** report matching the static tier (verify/remove scenarios only, no optional blocks), clear process env vars whose names start with `PSIGN_`, then run `scripts/run-parity-diff.ps1`. Expect **21** scenarios, `missingScenarioCount: 0`, and `semanticMismatchCount: 0` (UTF-16 `@rsp` remains `documented_native_utf16_rsp_gap`, not a semantic failure).
 
 ## Tier 2 — Extensions (`parity-extensions.yml`)

--- a/docs/migration-artifact-signing.md
+++ b/docs/migration-artifact-signing.md
@@ -173,6 +173,8 @@ Either **`PSIGN_ARTIFACT_SIGNING_DLIB`** or **`PSIGN_ARTIFACT_SIGNING_DLIB_ROOT`
 
 ### REST hash signing (gated smoke test)
 
+Automated CI does not need a real Trusted Signing account for REST submit coverage. **`psign-server artifact-signing-server`** serves a local **`:sign`** endpoint and pollable operation URL; feature-gated E2E tests call **`psign-tool portable artifact-signing-submit`** and, on Windows, **`psign-tool artifact-signing-submit`** with the local endpoint override.
+
 Build with **`--features artifact-signing-rest`**, then run the ignored test **`artifact_signing_rest_submit_smoke`** when you have a **Trusted Signing** account and a **raw digest file** (for example **32 bytes** for SHA-256):
 
 ```powershell

--- a/docs/migration-azuresigntool.md
+++ b/docs/migration-azuresigntool.md
@@ -116,4 +116,6 @@ Use the appropriate portable subcommands for your format (`verify-pe`, catalog c
 
 ## Integration testing
 
-Exercise the Key Vault path against a real vault (managed identity or client secret), then compare **`psign-tool verify`** and **`psign-tool portable`** results with a known-good AzureSignTool-signed artifact.
+Automated CI uses **`psign-server azure-key-vault-server`** as a local Key Vault replacement for digest signing. The non-ignored E2E test starts the server, calls **`psign-tool portable azure-key-vault-sign-digest`** with **`--azure-key-vault-url http://127.0.0.1:...`** and a dummy access token, then checks the returned RSA signature bytes. This exercises the same REST certificate lookup and **`keys/sign`** client used by the Windows signing path without contacting Azure.
+
+Full Windows PE signing through **`psign-tool sign --azure-key-vault-url ...`** is tracked separately because **`SignerSignEx3`** currently requires a local provider binding before a Key Vault-only certificate can be used for embedded signing. Until that is enabled as a non-ignored local test, use real-vault/manual validation for full AzureSignTool replacement signing and compare **`psign-tool verify`** plus **`psign-tool portable verify-pe`** results with a known-good AzureSignTool-signed artifact.

--- a/scripts/linux-portable-validation.sh
+++ b/scripts/linux-portable-validation.sh
@@ -47,8 +47,14 @@ cargo test -p psign --test cli_pe_digest --locked
 echo "== integration: psign-tool portable (artifact-signing-rest) =="
 cargo test -p psign --test cli_pe_digest --features artifact-signing-rest --locked
 
+echo "== integration: psign-tool portable + psign-server (artifact-signing-rest) =="
+cargo test -p psign --test cli_pe_digest --features timestamp-server,artifact-signing-rest --locked psign_server_artifact
+
 echo "== integration: psign-tool portable (azure-kv-sign-portable) =="
 cargo test -p psign --test cli_pe_digest --features azure-kv-sign --locked
+
+echo "== integration: psign-tool portable + psign-server (azure-kv-sign-portable) =="
+cargo test -p psign --test cli_pe_digest --features timestamp-server,azure-kv-sign --locked psign_server_azure_key_vault_signs_digest_for_portable_cli
 
 echo "== integration: psign-tool portable (timestamp-http) =="
 cargo test -p psign --test cli_pe_digest --features timestamp-http --locked

--- a/src/bin/psign-server.rs
+++ b/src/bin/psign-server.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, anyhow};
+use base64::Engine as _;
 use clap::{Parser, Subcommand, ValueEnum};
 use cms::builder::{SignedDataBuilder, SignerInfoBuilder};
 use cms::cert::{CertificateChoices, IssuerAndSerialNumber};
@@ -9,13 +10,16 @@ use rand::rngs::OsRng;
 use rsa::RsaPrivateKey;
 use rsa::pkcs1v15::SigningKey;
 use rsa::pkcs8::EncodePrivateKey;
-use rsa::signature::{Keypair, SignatureEncoding, Signer};
+use rsa::signature::{Keypair, SignatureEncoding, Signer, hazmat::PrehashSigner};
+use serde_json::Value;
 use sha1::Sha1;
-use sha2::{Digest as _, Sha256};
+use sha2::{Digest as _, Sha256, Sha384, Sha512};
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use x509_cert::Certificate;
@@ -55,6 +59,10 @@ enum Command {
     TimestampServer(TimestampServerArgs),
     /// Serve local code-signing PKI material for online certificate feature tests.
     PkiServer(PkiServerArgs),
+    /// Serve a local Azure Key Vault-compatible signing endpoint for tests.
+    AzureKeyVaultServer(AzureKeyVaultServerArgs),
+    /// Serve a local Azure Code Signing / Trusted Signing data-plane endpoint for tests.
+    ArtifactSigningServer(ArtifactSigningServerArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -107,6 +115,50 @@ struct PkiServerArgs {
     max_requests: u64,
 }
 
+#[derive(Parser, Debug)]
+struct AzureKeyVaultServerArgs {
+    /// Address to bind, for example 127.0.0.1:0 for an ephemeral port.
+    #[arg(long, default_value = "127.0.0.1:0")]
+    listen: String,
+    /// Certificate name accepted under /certificates/{name}.
+    #[arg(long, default_value = "psign-test-cert")]
+    certificate_name: String,
+    /// Key name embedded in the returned certificate kid.
+    #[arg(long, default_value = "psign-test-key")]
+    key_name: String,
+    /// Key/certificate version accepted in versioned URLs.
+    #[arg(long, default_value = "v1")]
+    version: String,
+    /// Write the generated root certificate as DER for local trust-anchor setup.
+    #[arg(long, value_name = "PATH")]
+    root_cert_output: Option<PathBuf>,
+    /// Write the generated code-signing leaf certificate as DER.
+    #[arg(long, value_name = "PATH")]
+    leaf_cert_output: Option<PathBuf>,
+    /// Exit after serving this many requests. Zero means run until interrupted.
+    #[arg(long, default_value_t = 0)]
+    max_requests: u64,
+}
+
+#[derive(Parser, Debug)]
+struct ArtifactSigningServerArgs {
+    /// Address to bind, for example 127.0.0.1:0 for an ephemeral port.
+    #[arg(long, default_value = "127.0.0.1:0")]
+    listen: String,
+    /// Deterministic response variant for positive and negative-path tests.
+    #[arg(long, value_enum, default_value_t = ArtifactResponseMode::Valid)]
+    response_mode: ArtifactResponseMode,
+    /// Write the generated root certificate as DER for local trust-anchor setup.
+    #[arg(long, value_name = "PATH")]
+    root_cert_output: Option<PathBuf>,
+    /// Write the generated code-signing leaf certificate as DER.
+    #[arg(long, value_name = "PATH")]
+    leaf_cert_output: Option<PathBuf>,
+    /// Exit after serving this many requests. Zero means run until interrupted.
+    #[arg(long, default_value_t = 0)]
+    max_requests: u64,
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum ServerStatus {
     Granted,
@@ -119,6 +171,20 @@ enum PkiOcspStatus {
     Good,
     Revoked,
     Unknown,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ArtifactResponseMode {
+    /// Return a normal accepted operation followed by a Succeeded poll body.
+    Valid,
+    /// Return HTTP 500 for the submit request.
+    HttpError,
+    /// Return an accepted operation whose poll body is Failed.
+    Failed,
+    /// Return an accepted operation whose poll body is Canceled.
+    Canceled,
+    /// Return HTTP 200 with malformed JSON for the submit request.
+    MalformedJson,
 }
 
 impl ServerStatus {
@@ -172,6 +238,8 @@ fn run() -> Result<()> {
     match Cli::parse().command {
         Command::TimestampServer(args) => run_timestamp_server(args),
         Command::PkiServer(args) => run_pki_server(args),
+        Command::AzureKeyVaultServer(args) => run_azure_key_vault_server(args),
+        Command::ArtifactSigningServer(args) => run_artifact_signing_server(args),
     }
 }
 
@@ -287,7 +355,17 @@ fn handle_client(
 struct HttpRequest {
     method: String,
     path: String,
+    headers: Vec<(String, String)>,
     body: Vec<u8>,
+}
+
+impl HttpRequest {
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
 }
 
 fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequest> {
@@ -325,6 +403,7 @@ fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequest> {
         .to_string();
     let content_len = headers
         .lines()
+        .skip(1)
         .find_map(|line| {
             let (name, value) = line.split_once(':')?;
             name.eq_ignore_ascii_case("content-length")
@@ -332,6 +411,14 @@ fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequest> {
                 .flatten()
         })
         .unwrap_or(0);
+    let parsed_headers = headers
+        .lines()
+        .skip(1)
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim().to_string(), value.trim().to_string()))
+        })
+        .collect();
     let body_start = header_end + 4;
     while buf.len() < body_start + content_len {
         let n = stream.read(&mut tmp).context("read HTTP body")?;
@@ -343,6 +430,7 @@ fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequest> {
     Ok(HttpRequest {
         method,
         path,
+        headers: parsed_headers,
         body: buf[body_start..body_start + content_len].to_vec(),
     })
 }
@@ -358,12 +446,27 @@ fn write_http_response(
     content_type: &str,
     body: &[u8],
 ) -> Result<()> {
+    write_http_response_with_headers(stream, status, reason, content_type, &[], body)
+}
+
+fn write_http_response_with_headers(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    content_type: &str,
+    headers: &[(&str, String)],
+    body: &[u8],
+) -> Result<()> {
     write!(
         stream,
-        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n",
         body.len()
     )
     .context("write HTTP response headers")?;
+    for (name, value) in headers {
+        write!(stream, "{name}: {value}\r\n").context("write HTTP response header")?;
+    }
+    write!(stream, "\r\n").context("finish HTTP response headers")?;
     stream.write_all(body).context("write HTTP response body")
 }
 
@@ -373,6 +476,28 @@ struct PkiAuthority {
     leaf_key_der: Vec<u8>,
     crl_der: Vec<u8>,
     ocsp_der: Vec<u8>,
+}
+
+struct AzureSigningIdentity {
+    root_cert: Certificate,
+    leaf_cert: Certificate,
+    leaf_key: RsaPrivateKey,
+}
+
+struct AzureKeyVaultAuthority {
+    identity: AzureSigningIdentity,
+    certificate_name: String,
+    key_name: String,
+    version: String,
+    base_url: String,
+}
+
+struct ArtifactSigningAuthority {
+    identity: AzureSigningIdentity,
+    response_mode: ArtifactResponseMode,
+    base_url: String,
+    next_operation: AtomicU64,
+    operations: Mutex<HashMap<String, Value>>,
 }
 
 fn run_pki_server(args: PkiServerArgs) -> Result<()> {
@@ -529,6 +654,458 @@ impl PkiAuthority {
             ocsp_der,
         })
     }
+}
+
+impl AzureSigningIdentity {
+    fn new(
+        root_common_name: &str,
+        leaf_common_name: &str,
+        root_serial: u32,
+        leaf_serial: u32,
+    ) -> Result<Self> {
+        let root_private_key =
+            RsaPrivateKey::new(&mut OsRng, 2048).context("generate Azure test root RSA key")?;
+        let root_key = SigningKey::<Sha256>::new(root_private_key);
+        let root_subject =
+            Name::from_str(&format!("CN={root_common_name}")).context("Azure test root subject")?;
+        let root_spki = SubjectPublicKeyInfoOwned::from_key(root_key.verifying_key())
+            .context("Azure test root subject public key info")?;
+        let root_builder = CertificateBuilder::new(
+            Profile::Root,
+            SerialNumber::from(root_serial),
+            Validity::from_now(Duration::from_secs(86_400 * 365))
+                .context("Azure test root validity")?,
+            root_subject.clone(),
+            root_spki,
+            &root_key,
+        )
+        .context("Azure test root certificate builder")?;
+        let root_cert = root_builder
+            .build::<rsa::pkcs1v15::Signature>()
+            .context("self-sign Azure test root certificate")?;
+
+        let leaf_key =
+            RsaPrivateKey::new(&mut OsRng, 2048).context("generate Azure test leaf RSA key")?;
+        let leaf_signing_key = SigningKey::<Sha256>::new(leaf_key.clone());
+        let leaf_subject =
+            Name::from_str(&format!("CN={leaf_common_name}")).context("Azure test leaf subject")?;
+        let leaf_spki = SubjectPublicKeyInfoOwned::from_key(leaf_signing_key.verifying_key())
+            .context("Azure test leaf subject public key info")?;
+        let mut leaf_builder = CertificateBuilder::new(
+            Profile::Leaf {
+                issuer: root_subject,
+                enable_key_agreement: false,
+                enable_key_encipherment: false,
+            },
+            SerialNumber::from(leaf_serial),
+            Validity::from_now(Duration::from_secs(86_400 * 365))
+                .context("Azure test leaf validity")?,
+            leaf_subject,
+            leaf_spki,
+            &root_key,
+        )
+        .context("Azure test leaf certificate builder")?;
+        leaf_builder
+            .add_extension(&ExtendedKeyUsage(vec![OID_CODE_SIGNING]))
+            .context("add Azure test code-signing EKU")?;
+        let leaf_cert = leaf_builder
+            .build::<rsa::pkcs1v15::Signature>()
+            .context("sign Azure test leaf certificate")?;
+
+        Ok(Self {
+            root_cert,
+            leaf_cert,
+            leaf_key,
+        })
+    }
+
+    fn leaf_der(&self) -> Result<Vec<u8>> {
+        self.leaf_cert
+            .to_der()
+            .context("encode Azure test leaf certificate")
+    }
+
+    fn sign_digest(&self, alg: &str, digest: &[u8]) -> Result<Vec<u8>> {
+        match alg.trim() {
+            "RS256" => {
+                if digest.len() != 32 {
+                    return Err(anyhow!("RS256 requires a 32-byte SHA-256 digest"));
+                }
+                let key = SigningKey::<Sha256>::new(self.leaf_key.clone());
+                Ok(key
+                    .sign_prehash(digest)
+                    .map_err(|e| anyhow!("RS256 prehash sign: {e}"))?
+                    .to_bytes()
+                    .to_vec())
+            }
+            "RS384" => {
+                if digest.len() != 48 {
+                    return Err(anyhow!("RS384 requires a 48-byte SHA-384 digest"));
+                }
+                let key = SigningKey::<Sha384>::new(self.leaf_key.clone());
+                Ok(key
+                    .sign_prehash(digest)
+                    .map_err(|e| anyhow!("RS384 prehash sign: {e}"))?
+                    .to_bytes()
+                    .to_vec())
+            }
+            "RS512" => {
+                if digest.len() != 64 {
+                    return Err(anyhow!("RS512 requires a 64-byte SHA-512 digest"));
+                }
+                let key = SigningKey::<Sha512>::new(self.leaf_key.clone());
+                Ok(key
+                    .sign_prehash(digest)
+                    .map_err(|e| anyhow!("RS512 prehash sign: {e}"))?
+                    .to_bytes()
+                    .to_vec())
+            }
+            other => Err(anyhow!("unsupported Azure test signing algorithm {other}")),
+        }
+    }
+}
+
+fn write_generated_azure_certs(
+    identity: &AzureSigningIdentity,
+    root_output: &Option<PathBuf>,
+    leaf_output: &Option<PathBuf>,
+) -> Result<()> {
+    if let Some(path) = root_output {
+        std::fs::write(
+            path,
+            identity
+                .root_cert
+                .to_der()
+                .context("encode generated Azure test root certificate")?,
+        )
+        .with_context(|| {
+            format!(
+                "write generated Azure test root certificate {}",
+                path.display()
+            )
+        })?;
+    }
+    if let Some(path) = leaf_output {
+        std::fs::write(path, identity.leaf_der()?).with_context(|| {
+            format!(
+                "write generated Azure test leaf certificate {}",
+                path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn run_azure_key_vault_server(args: AzureKeyVaultServerArgs) -> Result<()> {
+    let listener =
+        TcpListener::bind(&args.listen).with_context(|| format!("bind {}", args.listen))?;
+    let local = listener.local_addr().context("read listener address")?;
+    let base_url = format!("http://{local}/");
+    let authority = AzureKeyVaultAuthority {
+        identity: AzureSigningIdentity::new(
+            "psign local Azure Key Vault test root CA",
+            "psign local Azure Key Vault code signing leaf",
+            20,
+            21,
+        )?,
+        certificate_name: args.certificate_name,
+        key_name: args.key_name,
+        version: args.version,
+        base_url: base_url.clone(),
+    };
+    write_generated_azure_certs(
+        &authority.identity,
+        &args.root_cert_output,
+        &args.leaf_cert_output,
+    )?;
+
+    println!("psign-server azure-key-vault-server listening on {base_url}");
+    println!(
+        "psign-server azure-key-vault-server certificate {}",
+        authority.certificate_name
+    );
+    println!(
+        "psign-server azure-key-vault-server leaf {base_url}certificates/{}",
+        authority.certificate_name
+    );
+    std::io::stdout().flush().ok();
+
+    for (served, stream) in listener.incoming().enumerate() {
+        let stream = stream.context("accept HTTP client")?;
+        if let Err(e) = handle_azure_key_vault_client(stream, &authority) {
+            eprintln!("request failed: {e:#}");
+        }
+        if args.max_requests != 0 && (served as u64 + 1) >= args.max_requests {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn run_artifact_signing_server(args: ArtifactSigningServerArgs) -> Result<()> {
+    let listener =
+        TcpListener::bind(&args.listen).with_context(|| format!("bind {}", args.listen))?;
+    let local = listener.local_addr().context("read listener address")?;
+    let base_url = format!("http://{local}/");
+    let authority = ArtifactSigningAuthority {
+        identity: AzureSigningIdentity::new(
+            "psign local Artifact Signing test root CA",
+            "psign local Artifact Signing code signing leaf",
+            30,
+            31,
+        )?,
+        response_mode: args.response_mode,
+        base_url: base_url.clone(),
+        next_operation: AtomicU64::new(1),
+        operations: Mutex::new(HashMap::new()),
+    };
+    write_generated_azure_certs(
+        &authority.identity,
+        &args.root_cert_output,
+        &args.leaf_cert_output,
+    )?;
+
+    println!("psign-server artifact-signing-server listening on {base_url}");
+    println!("psign-server artifact-signing-server endpoint {base_url}");
+    std::io::stdout().flush().ok();
+
+    for (served, stream) in listener.incoming().enumerate() {
+        let stream = stream.context("accept HTTP client")?;
+        if let Err(e) = handle_artifact_signing_client(stream, &authority) {
+            eprintln!("request failed: {e:#}");
+        }
+        if args.max_requests != 0 && (served as u64 + 1) >= args.max_requests {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn handle_azure_key_vault_client(
+    mut stream: TcpStream,
+    authority: &AzureKeyVaultAuthority,
+) -> Result<()> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .context("set read timeout")?;
+    let request = read_http_request(&mut stream)?;
+    if !has_bearer_token(&request) {
+        return write_json_response(
+            &mut stream,
+            401,
+            "Unauthorized",
+            &serde_json::json!({"error":{"code":"Unauthorized","message":"missing bearer token"}}),
+        );
+    }
+
+    let path = path_without_query(&request.path);
+    let cert_path = format!("/certificates/{}", authority.certificate_name);
+    let cert_version_path = format!("{cert_path}/{}", authority.version);
+    let sign_path = format!(
+        "/keys/{}/versions/{}/sign",
+        authority.key_name, authority.version
+    );
+
+    match (request.method.as_str(), path) {
+        ("GET", p) if p == cert_path || p == cert_version_path => {
+            let leaf_der = authority.identity.leaf_der()?;
+            let kid = format!(
+                "{}keys/{}/versions/{}",
+                authority.base_url, authority.key_name, authority.version
+            );
+            write_json_response(
+                &mut stream,
+                200,
+                "OK",
+                &serde_json::json!({
+                    "id": format!("{}certificates/{}/{}", authority.base_url, authority.certificate_name, authority.version),
+                    "kid": kid,
+                    "cer": base64::engine::general_purpose::STANDARD.encode(leaf_der),
+                }),
+            )
+        }
+        ("POST", p) if p == sign_path => {
+            let body: Value =
+                serde_json::from_slice(&request.body).context("Key Vault sign JSON")?;
+            let alg = body
+                .get("alg")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Key Vault sign body missing alg"))?;
+            let digest_b64 = body
+                .get("value")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Key Vault sign body missing value"))?;
+            let digest = base64::engine::general_purpose::STANDARD
+                .decode(digest_b64.trim())
+                .context("decode Key Vault sign digest")?;
+            let signature = authority.identity.sign_digest(alg, &digest)?;
+            write_json_response(
+                &mut stream,
+                200,
+                "OK",
+                &serde_json::json!({
+                    "kid": format!("{}keys/{}/versions/{}", authority.base_url, authority.key_name, authority.version),
+                    "value": base64::engine::general_purpose::STANDARD.encode(signature),
+                }),
+            )
+        }
+        _ => write_http_response(&mut stream, 404, "Not Found", "text/plain", b"not found\n"),
+    }
+}
+
+fn handle_artifact_signing_client(
+    mut stream: TcpStream,
+    authority: &ArtifactSigningAuthority,
+) -> Result<()> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .context("set read timeout")?;
+    let request = read_http_request(&mut stream)?;
+    if !has_bearer_token(&request) {
+        return write_json_response(
+            &mut stream,
+            401,
+            "Unauthorized",
+            &serde_json::json!({"error":{"code":"Unauthorized","message":"missing bearer token"}}),
+        );
+    }
+
+    let path = path_without_query(&request.path);
+    if request.method == "GET" {
+        if let Some(id) = path.strip_prefix("/operations/") {
+            let operations = authority
+                .operations
+                .lock()
+                .map_err(|_| anyhow!("artifact signing operation store poisoned"))?;
+            if let Some(body) = operations.get(id) {
+                return write_json_response(&mut stream, 200, "OK", body);
+            }
+        }
+        return write_http_response(&mut stream, 404, "Not Found", "text/plain", b"not found\n");
+    }
+
+    if request.method != "POST" {
+        return write_http_response(
+            &mut stream,
+            405,
+            "Method Not Allowed",
+            "text/plain",
+            b"method not allowed\n",
+        );
+    }
+    let Some((account, profile)) = parse_artifact_sign_path(path) else {
+        return write_http_response(&mut stream, 404, "Not Found", "text/plain", b"not found\n");
+    };
+
+    match authority.response_mode {
+        ArtifactResponseMode::HttpError => {
+            return write_json_response(
+                &mut stream,
+                500,
+                "Internal Server Error",
+                &serde_json::json!({"error":{"code":"InjectedFailure"}}),
+            );
+        }
+        ArtifactResponseMode::MalformedJson => {
+            return write_http_response(&mut stream, 200, "OK", "application/json", b"{not-json");
+        }
+        ArtifactResponseMode::Valid
+        | ArtifactResponseMode::Failed
+        | ArtifactResponseMode::Canceled => {}
+    }
+
+    let body: Value =
+        serde_json::from_slice(&request.body).context("Artifact Signing submit JSON")?;
+    let alg = body
+        .get("signatureAlgorithm")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("Artifact Signing submit body missing signatureAlgorithm"))?;
+    let digest_b64 = body
+        .get("digest")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("Artifact Signing submit body missing digest"))?;
+    let digest = base64::engine::general_purpose::STANDARD
+        .decode(digest_b64.trim())
+        .context("decode Artifact Signing digest")?;
+
+    let operation_id = format!(
+        "op-{}",
+        authority.next_operation.fetch_add(1, Ordering::Relaxed)
+    );
+    let operation_body = match authority.response_mode {
+        ArtifactResponseMode::Valid => {
+            let signature = authority.identity.sign_digest(alg, &digest)?;
+            serde_json::json!({
+                "id": operation_id,
+                "status": "Succeeded",
+                "signature": base64::engine::general_purpose::STANDARD.encode(signature),
+                "signingCertificate": base64::engine::general_purpose::STANDARD.encode(authority.identity.leaf_der()?),
+                "codeSigningAccountName": account,
+                "certificateProfileName": profile,
+            })
+        }
+        ArtifactResponseMode::Failed => serde_json::json!({
+            "id": operation_id,
+            "status": "Failed",
+            "error": {"code": "InjectedFailure", "message": "psign-server injected failure"}
+        }),
+        ArtifactResponseMode::Canceled => serde_json::json!({
+            "id": operation_id,
+            "status": "Canceled"
+        }),
+        ArtifactResponseMode::HttpError | ArtifactResponseMode::MalformedJson => unreachable!(),
+    };
+    authority
+        .operations
+        .lock()
+        .map_err(|_| anyhow!("artifact signing operation store poisoned"))?
+        .insert(operation_id.clone(), operation_body);
+
+    let operation_location = format!("{}operations/{operation_id}", authority.base_url);
+    write_http_response_with_headers(
+        &mut stream,
+        202,
+        "Accepted",
+        "application/json",
+        &[("Operation-Location", operation_location)],
+        br#"{"status":"InProgress"}"#,
+    )
+}
+
+fn path_without_query(path: &str) -> &str {
+    path.split_once('?').map(|(p, _)| p).unwrap_or(path)
+}
+
+fn has_bearer_token(request: &HttpRequest) -> bool {
+    request
+        .header("authorization")
+        .and_then(|h| h.trim().strip_prefix("Bearer "))
+        .map(|t| !t.trim().is_empty())
+        .unwrap_or(false)
+}
+
+fn parse_artifact_sign_path(path: &str) -> Option<(&str, &str)> {
+    let mut segments = path.trim_matches('/').split('/');
+    let first = segments.next()?;
+    let account = segments.next()?;
+    let third = segments.next()?;
+    let profile_sign = segments.next()?;
+    if segments.next().is_some() || first != "codesigningaccounts" || third != "certificateprofiles"
+    {
+        return None;
+    }
+    let profile = profile_sign.strip_suffix(":sign")?;
+    Some((account, profile))
+}
+
+fn write_json_response(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    body: &Value,
+) -> Result<()> {
+    let body = serde_json::to_vec(body).context("encode JSON response")?;
+    write_http_response(stream, status, reason, "application/json", &body)
 }
 
 fn build_ocsp_response_der(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -336,6 +336,9 @@ pub struct ArtifactSigningSubmitArgs {
     pub client_secret: Option<String>,
     #[arg(long)]
     pub authority: Option<String>,
+    /// Override data-plane origin for deterministic local tests.
+    #[arg(long, hide = true)]
+    pub endpoint_base_url: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/win/artifact_signing_rest.rs
+++ b/src/win/artifact_signing_rest.rs
@@ -32,7 +32,7 @@ pub fn artifact_signing_submit_command(
         correlation_id: args.correlation_id.clone(),
         authority: args.authority.clone(),
         auth,
-        endpoint_base_url: None,
+        endpoint_base_url: args.endpoint_base_url.clone(),
     };
 
     let debug = |msg: &str| {

--- a/tests/cli_pe_digest.rs
+++ b/tests/cli_pe_digest.rs
@@ -1,6 +1,8 @@
 //! End-to-end CLI smoke test (runs on Linux CI).
 
 use assert_cmd::Command;
+#[cfg(feature = "artifact-signing-rest")]
+use base64::Engine as _;
 use predicates::prelude::*;
 use psign_authenticode_trust::pe_first_pkcs7_terminal_root;
 use psign_authenticode_trust::{inspect_authenticode_pkcs7_der, inspect_pe_authenticode};
@@ -2733,6 +2735,69 @@ fn spawn_psign_pki_server_requests(
     (guard, url)
 }
 
+#[cfg(all(feature = "timestamp-server", feature = "azure-kv-sign"))]
+fn spawn_psign_azure_key_vault_server(max_requests: u64) -> (PsignServerGuard, String, String) {
+    let mut server_cmd = std::process::Command::new(assert_cmd::cargo::cargo_bin("psign-server"));
+    let max_requests = max_requests.to_string();
+    server_cmd.args([
+        "azure-key-vault-server",
+        "--listen",
+        "127.0.0.1:0",
+        "--max-requests",
+        max_requests.as_str(),
+    ]);
+    server_cmd.stdout(std::process::Stdio::piped());
+    server_cmd.stderr(std::process::Stdio::piped());
+    let mut guard = PsignServerGuard(server_cmd.spawn().expect("spawn psign-server"));
+    let stdout = guard.0.stdout.take().expect("server stdout");
+    let mut reader = std::io::BufReader::new(stdout);
+    let mut listen_line = String::new();
+    std::io::BufRead::read_line(&mut reader, &mut listen_line).expect("read listening line");
+    let mut cert_line = String::new();
+    std::io::BufRead::read_line(&mut reader, &mut cert_line).expect("read certificate line");
+    let mut ignored = String::new();
+    std::io::BufRead::read_line(&mut reader, &mut ignored).expect("read leaf line");
+    let url = listen_line
+        .trim()
+        .strip_prefix("psign-server azure-key-vault-server listening on ")
+        .expect("listening URL")
+        .to_string();
+    let certificate = cert_line
+        .trim()
+        .strip_prefix("psign-server azure-key-vault-server certificate ")
+        .expect("certificate name")
+        .to_string();
+    (guard, url, certificate)
+}
+
+#[cfg(all(feature = "timestamp-server", feature = "artifact-signing-rest"))]
+fn spawn_psign_artifact_signing_server(max_requests: u64) -> (PsignServerGuard, String) {
+    let mut server_cmd = std::process::Command::new(assert_cmd::cargo::cargo_bin("psign-server"));
+    let max_requests = max_requests.to_string();
+    server_cmd.args([
+        "artifact-signing-server",
+        "--listen",
+        "127.0.0.1:0",
+        "--max-requests",
+        max_requests.as_str(),
+    ]);
+    server_cmd.stdout(std::process::Stdio::piped());
+    server_cmd.stderr(std::process::Stdio::piped());
+    let mut guard = PsignServerGuard(server_cmd.spawn().expect("spawn psign-server"));
+    let stdout = guard.0.stdout.take().expect("server stdout");
+    let mut reader = std::io::BufReader::new(stdout);
+    let mut listen_line = String::new();
+    std::io::BufRead::read_line(&mut reader, &mut listen_line).expect("read listening line");
+    let mut ignored = String::new();
+    std::io::BufRead::read_line(&mut reader, &mut ignored).expect("read endpoint line");
+    let url = listen_line
+        .trim()
+        .strip_prefix("psign-server artifact-signing-server listening on ")
+        .expect("listening URL")
+        .to_string();
+    (guard, url)
+}
+
 #[cfg(feature = "timestamp-server")]
 fn http_get_bytes(url: &str) -> Vec<u8> {
     use std::io::{Read, Write};
@@ -2884,6 +2949,155 @@ fn psign_server_pki_server_serves_signed_crls() {
     assert!(
         revoked_crl.len() > crl.len(),
         "revoked CRL should include a revoked certificate entry"
+    );
+}
+
+#[cfg(all(feature = "timestamp-server", feature = "azure-kv-sign"))]
+#[test]
+fn psign_server_azure_key_vault_signs_digest_for_portable_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let digest_path = dir.path().join("digest.bin");
+    let sig_path = dir.path().join("sig.bin");
+    std::fs::write(&digest_path, [0xabu8; 32]).expect("write digest");
+
+    let (mut guard, url, certificate) = spawn_psign_azure_key_vault_server(2);
+    let mut cmd = portable_cmd();
+    cmd.arg("azure-key-vault-sign-digest")
+        .arg("--azure-key-vault-url")
+        .arg(&url)
+        .arg("--azure-key-vault-certificate")
+        .arg(&certificate)
+        .arg("--digest-file")
+        .arg(&digest_path)
+        .arg("--digest-algorithm")
+        .arg("sha256")
+        .arg("--azure-key-vault-accesstoken")
+        .arg("test-token")
+        .arg("--signature-output")
+        .arg(&sig_path);
+    cmd.assert().success();
+    let status = guard.0.wait().expect("server exit");
+    assert!(status.success(), "server failed with {status}");
+
+    let sig = std::fs::read(&sig_path).expect("read signature");
+    assert_eq!(sig.len(), 256, "RSA-2048 signature length");
+    assert!(
+        sig.iter().any(|b| *b != 0),
+        "signature should not be all zeros"
+    );
+}
+
+#[cfg(all(feature = "timestamp-server", feature = "artifact-signing-rest"))]
+#[test]
+fn psign_server_artifact_signing_submit_serves_portable_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let digest_path = dir.path().join("digest.bin");
+    std::fs::write(&digest_path, [0xcdu8; 32]).expect("write digest");
+
+    let (mut guard, endpoint) = spawn_psign_artifact_signing_server(2);
+    let mut cmd = portable_cmd();
+    cmd.arg("artifact-signing-submit")
+        .arg("--region")
+        .arg("local")
+        .arg("--account-name")
+        .arg("acct")
+        .arg("--profile-name")
+        .arg("prof")
+        .arg("--digest-file")
+        .arg(&digest_path)
+        .arg("--access-token")
+        .arg("test-token")
+        .arg("--endpoint-base-url")
+        .arg(&endpoint);
+    let output = cmd.output().expect("run artifact-signing-submit");
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status = guard.0.wait().expect("server exit");
+    assert!(status.success(), "server failed with {status}");
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse submit JSON");
+    assert_eq!(
+        json.get("status").and_then(Value::as_str),
+        Some("Succeeded")
+    );
+    let sig = json
+        .get("signature")
+        .and_then(Value::as_str)
+        .and_then(|s| base64::engine::general_purpose::STANDARD.decode(s).ok())
+        .expect("base64 signature");
+    assert_eq!(sig.len(), 256, "RSA-2048 signature length");
+}
+
+#[cfg(all(windows, feature = "timestamp-server", feature = "azure-kv-sign"))]
+#[test]
+#[ignore = "current Azure KV SignerSignEx3 path requires a local provider binding before full PE signing can be automated"]
+fn psign_server_azure_key_vault_signs_pe_with_windows_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let pe_path = dir.path().join("tiny32.kv-signed.exe");
+    std::fs::copy(tiny32_unsigned_fixture(), &pe_path).expect("copy unsigned PE");
+
+    let (mut guard, url, certificate) = spawn_psign_azure_key_vault_server(2);
+    let mut cmd = Command::cargo_bin("psign-tool").unwrap();
+    cmd.arg("sign")
+        .arg("--digest")
+        .arg("sha256")
+        .arg("--azure-key-vault-url")
+        .arg(&url)
+        .arg("--azure-key-vault-certificate")
+        .arg(&certificate)
+        .arg("--azure-key-vault-accesstoken")
+        .arg("test-token")
+        .arg(&pe_path);
+    cmd.assert().success();
+    let status = guard.0.wait().expect("server exit");
+    assert!(status.success(), "server failed with {status}");
+
+    let mut verify = portable_cmd();
+    verify.arg("verify-pe").arg(&pe_path);
+    verify.assert().success();
+}
+
+#[cfg(all(
+    windows,
+    feature = "timestamp-server",
+    feature = "artifact-signing-rest"
+))]
+#[test]
+fn psign_server_artifact_signing_submit_serves_windows_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let digest_path = dir.path().join("digest.bin");
+    std::fs::write(&digest_path, [0x11u8; 32]).expect("write digest");
+
+    let (mut guard, endpoint) = spawn_psign_artifact_signing_server(2);
+    let mut cmd = Command::cargo_bin("psign-tool").unwrap();
+    cmd.arg("artifact-signing-submit")
+        .arg("--region")
+        .arg("local")
+        .arg("--account-name")
+        .arg("acct")
+        .arg("--profile-name")
+        .arg("prof")
+        .arg("--digest-file")
+        .arg(&digest_path)
+        .arg("--access-token")
+        .arg("test-token")
+        .arg("--endpoint-base-url")
+        .arg(&endpoint);
+    let output = cmd.output().expect("run artifact-signing-submit");
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status = guard.0.wait().expect("server exit");
+    assert!(status.success(), "server failed with {status}");
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse submit JSON");
+    assert_eq!(
+        json.get("status").and_then(Value::as_str),
+        Some("Succeeded")
     );
 }
 


### PR DESCRIPTION
## Summary
- add psign-server Azure Key Vault and Artifact Signing local test services
- add psign-tool endpoint override support for local Artifact Signing E2E
- add psign-server-backed Azure signing tests and validation/docs updates

## Validation
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings