### PR TITLE
Add portable PowerShell validation API

### DIFF
--- a/crates/psign-portable-core/src/lib.rs
+++ b/crates/psign-portable-core/src/lib.rs
@@ -153,6 +153,50 @@ impl PortableGetSignatureRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PortableValidatePowerShellRequest {
+    pub source_path_or_extension: PathBuf,
+    pub content_base64: String,
+    #[serde(default)]
+    pub trusted_certificate_paths: Vec<PathBuf>,
+    #[serde(default)]
+    pub trusted_certificates_der_base64: Vec<String>,
+    #[serde(default)]
+    pub anchor_directory: Option<PathBuf>,
+    #[serde(default)]
+    pub authroot_cab: Option<PathBuf>,
+    #[serde(default)]
+    pub as_of: Option<String>,
+    #[serde(default)]
+    pub prefer_timestamp_signing_time: bool,
+    #[serde(default)]
+    pub require_valid_timestamp: bool,
+    #[serde(default)]
+    pub online_aia: bool,
+    #[serde(default)]
+    pub online_ocsp: bool,
+    #[serde(default)]
+    pub revocation_mode: PortableRevocationMode,
+}
+
+impl PortableValidatePowerShellRequest {
+    fn trust_request(&self) -> PortableGetSignatureRequest {
+        PortableGetSignatureRequest {
+            path: self.source_path_or_extension.clone(),
+            trusted_certificate_paths: self.trusted_certificate_paths.clone(),
+            trusted_certificates_der_base64: self.trusted_certificates_der_base64.clone(),
+            anchor_directory: self.anchor_directory.clone(),
+            authroot_cab: self.authroot_cab.clone(),
+            as_of: self.as_of.clone(),
+            prefer_timestamp_signing_time: self.prefer_timestamp_signing_time,
+            require_valid_timestamp: self.require_valid_timestamp,
+            online_aia: self.online_aia,
+            online_ocsp: self.online_ocsp,
+            revocation_mode: self.revocation_mode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PortableSignRequest {
     pub path: PathBuf,
     #[serde(default)]
@@ -363,6 +407,29 @@ pub fn portable_get_signature(
     Ok(response)
 }
 
+pub fn portable_validate_powershell_script(
+    request: PortableValidatePowerShellRequest,
+) -> Result<PortableSignatureResponse> {
+    let data = base64::engine::general_purpose::STANDARD
+        .decode(&request.content_base64)
+        .context("decode content_base64")?;
+    let format = infer_powershell_source_format(&request.source_path_or_extension);
+    if format != PortableFileFormat::PowerShellScript {
+        return Ok(base_response(
+            request.source_path_or_extension,
+            format,
+            PortableSignatureStatus::NotSupportedFileFormat,
+            "Unsupported file format for portable PowerShell signature validation.",
+        ));
+    }
+
+    let mut response = inspect_script(&request.source_path_or_extension, &data)?;
+    let trust_request = request.trust_request();
+    apply_trust_if_requested(&trust_request, format, &data, &mut response)?;
+
+    Ok(response)
+}
+
 pub fn infer_format(path: &Path) -> PortableFileFormat {
     let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
         return PortableFileFormat::Unknown;
@@ -385,6 +452,23 @@ pub fn infer_format(path: &Path) -> PortableFileFormat {
         }
         "vbs" | "js" | "wsf" => PortableFileFormat::WshScript,
         _ => PortableFileFormat::Unknown,
+    }
+}
+
+fn infer_powershell_source_format(path: &Path) -> PortableFileFormat {
+    let format = infer_format(path);
+    if format != PortableFileFormat::Unknown {
+        return format;
+    }
+
+    let Some(source) = path.file_name().and_then(|name| name.to_str()) else {
+        return PortableFileFormat::Unknown;
+    };
+    let extension = source.trim_start_matches('.');
+    if ps_script::extension_supported(extension) {
+        PortableFileFormat::PowerShellScript
+    } else {
+        PortableFileFormat::Unknown
     }
 }
 
@@ -1595,7 +1679,7 @@ fn inspect_script(path: &Path, data: &[u8]) -> Result<PortableSignatureResponse>
             Ok(PortableSignatureResponse {
                 schema_version: SCHEMA_VERSION,
                 path: path.to_path_buf(),
-                format: infer_format(path),
+                format: infer_powershell_source_format(path),
                 status: PortableSignatureStatus::Valid,
                 status_message: "Portable script digest binding is valid; trust was not evaluated."
                     .to_string(),
@@ -1611,7 +1695,11 @@ fn inspect_script(path: &Path, data: &[u8]) -> Result<PortableSignatureResponse>
                 diagnostics: Vec::new(),
             })
         }
-        Err(error) => Ok(map_digest_error(path, infer_format(path), error)),
+        Err(error) => Ok(map_digest_error(
+            path,
+            infer_powershell_source_format(path),
+            error,
+        )),
     }
 }
 
@@ -2068,6 +2156,94 @@ mod tests {
             infer_format(Path::new("unknown.bin")),
             PortableFileFormat::Unknown
         );
+    }
+
+    #[test]
+    fn infers_powershell_source_extensions() {
+        assert_eq!(
+            infer_powershell_source_format(Path::new(".ps1")),
+            PortableFileFormat::PowerShellScript
+        );
+        assert_eq!(
+            infer_powershell_source_format(Path::new("psm1")),
+            PortableFileFormat::PowerShellScript
+        );
+        assert_eq!(
+            infer_powershell_source_format(Path::new("unknown")),
+            PortableFileFormat::Unknown
+        );
+    }
+
+    #[test]
+    fn validates_unsigned_powershell_content_without_temp_file() {
+        let request = PortableValidatePowerShellRequest {
+            source_path_or_extension: PathBuf::from(".ps1"),
+            content_base64: base64::engine::general_purpose::STANDARD
+                .encode(b"Write-Output 'unsigned'\n"),
+            trusted_certificate_paths: Vec::new(),
+            trusted_certificates_der_base64: Vec::new(),
+            anchor_directory: None,
+            authroot_cab: None,
+            as_of: None,
+            prefer_timestamp_signing_time: false,
+            require_valid_timestamp: false,
+            online_aia: false,
+            online_ocsp: false,
+            revocation_mode: PortableRevocationMode::Off,
+        };
+        let response = portable_validate_powershell_script(request).expect("validate content");
+        assert_eq!(response.status, PortableSignatureStatus::NotSigned);
+        assert_eq!(response.format, PortableFileFormat::PowerShellScript);
+    }
+
+    #[test]
+    fn validates_signed_powershell_content_with_explicit_trust() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "psign-portable-script-trust-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let script_path = temp_dir.join("trusted.ps1");
+        let signed_path = temp_dir.join("trusted.signed.ps1");
+        std::fs::write(&script_path, b"Write-Output 'trusted'\r\n").expect("write script");
+
+        let fixture_dir = PathBuf::from("../../tests/fixtures/devolutions-authenticode");
+        let sign_request = PortableSignRequest {
+            path: script_path,
+            output_path: Some(signed_path.clone()),
+            pfx_path: Some(fixture_dir.join("authenticode-test-cert.pfx")),
+            pfx_password: Some("CodeSign123!".to_string()),
+            chain_certificate_paths: vec![fixture_dir.join("authenticode-test-ca.crt")],
+            ..default_sign_request()
+        };
+        portable_sign(sign_request).expect("sign script");
+
+        let signed = std::fs::read(&signed_path).expect("read signed script");
+        let validate_request = PortableValidatePowerShellRequest {
+            source_path_or_extension: PathBuf::from(".ps1"),
+            content_base64: base64::engine::general_purpose::STANDARD.encode(signed),
+            trusted_certificate_paths: vec![fixture_dir.join("authenticode-test-ca.crt")],
+            trusted_certificates_der_base64: Vec::new(),
+            anchor_directory: None,
+            authroot_cab: None,
+            as_of: None,
+            prefer_timestamp_signing_time: false,
+            require_valid_timestamp: false,
+            online_aia: false,
+            online_ocsp: false,
+            revocation_mode: PortableRevocationMode::Off,
+        };
+        let response =
+            portable_validate_powershell_script(validate_request).expect("validate signed script");
+        assert_eq!(response.status, PortableSignatureStatus::Valid);
+        assert_eq!(response.trust_status, Some(PortableSignatureStatus::Valid));
+        assert!(response.signer_certificate_der_base64.is_some());
+
+        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[test]

--- a/crates/psign-portable-ffi/src/lib.rs
+++ b/crates/psign-portable-ffi/src/lib.rs
@@ -4,7 +4,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use psign_portable_core::{
     PortableErrorCode, PortableErrorResponse, portable_error_response, portable_get_signature,
-    portable_sign, version,
+    portable_sign, portable_validate_powershell_script, version,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -63,6 +63,24 @@ pub unsafe extern "C" fn psign_core_get_signature(
     request_json_len: usize,
 ) -> PsignFfiResult {
     invoke_json(request_json_ptr, request_json_len, portable_get_signature)
+}
+
+/// Validate a PowerShell script/module signature from in-memory content.
+///
+/// # Safety
+///
+/// `request_json_ptr` must point to `request_json_len` readable UTF-8 bytes for the duration
+/// of the call. The returned buffer must be released with `psign_core_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn psign_core_validate_powershell_script(
+    request_json_ptr: *const u8,
+    request_json_len: usize,
+) -> PsignFfiResult {
+    invoke_json(
+        request_json_ptr,
+        request_json_len,
+        portable_validate_powershell_script,
+    )
 }
 
 /// Sign a file with the portable Authenticode core.
@@ -188,5 +206,17 @@ mod tests {
         assert_eq!(result.status_code, STATUS_INVALID_REQUEST);
         let json = unsafe { result_json(result) };
         assert!(json.contains("InvalidRequest"));
+    }
+
+    #[test]
+    fn validate_powershell_script_returns_json() {
+        let request =
+            br#"{"source_path_or_extension":".ps1","content_base64":"V3JpdGUtT3V0cHV0IDENCg=="}"#;
+        let result =
+            unsafe { psign_core_validate_powershell_script(request.as_ptr(), request.len()) };
+        assert_eq!(result.status_code, STATUS_OK);
+        let json = unsafe { result_json(result) };
+        assert!(json.contains("PowerShellScript"));
+        assert!(json.contains("NotSigned"));
     }
 }

--- a/docs/portable-core-ffi.md
+++ b/docs/portable-core-ffi.md
@@ -6,6 +6,7 @@ The ABI is intentionally small and JSON-based:
 
 - `psign_core_version()`
 - `psign_core_get_signature(request_json_ptr, request_json_len)`
+- `psign_core_validate_powershell_script(request_json_ptr, request_json_len)`
 - `psign_core_sign(request_json_ptr, request_json_len)`
 - `psign_core_free(buffer)`
 
@@ -14,3 +15,5 @@ All request and response JSON uses UTF-8. Callers pass borrowed input buffers; R
 The first schema version supports portable digest/signature inspection and local RSA signing for PE, CAB, MSI, ZIP Authenticode, MSIX/AppX packages, and PowerShell script inputs. `Set-PsignSignature` accepts certificate/key paths, exportable `X509Certificate2` values, exportable PFX files, chain certificates, RFC3161 timestamp settings, and portable cert-store material resolved by managed callers. `Set-PsignSignature` and `Get-PsignSignature` also accept PowerShell module directories and expand them to signable `.ps1`, `.psm1`, and `.psd1` files.
 
 `psign_core_get_signature` also accepts explicit trust material in the JSON request: trusted certificate paths, DER-encoded trusted certificates, anchor directory, AuthRoot CAB, `as_of`, timestamp-time policy booleans, online AIA/OCSP toggles, and revocation mode. The portable core never falls back to OS trust; when trust is requested, the response includes `trust_status` in addition to the digest/signature `status`.
+
+`psign_core_validate_powershell_script` is the embedding-oriented variant for patched PowerShell hosts. Its request contains `source_path_or_extension`, `content_base64`, and the same explicit trust fields as `psign_core_get_signature`. The function validates `.ps1`, `.psm1`, `.psd1`, `.ps1xml`, `.psc1`, `.cdxml`, and `.mof` content from memory so policy enforcement can avoid temporary files and shelling out.


### PR DESCRIPTION
## Summary
- add an in-memory PowerShell script/module validation request to `psign-portable-core`
- expose the validation path through the existing JSON FFI as `psign_core_validate_powershell_script`
- document the embedding-oriented FFI entrypoint and supported PowerShell source types

## Validation
- `cargo fmt --all`
- `cargo test -p psign-portable-core -p psign-portable-ffi --locked --quiet`