### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Release version to build/publish (for example 0.5.0)
+        description: Release version to build/publish (for example 0.5.1)
         required: true
         type: string
       publish_nuget:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "psign"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "psign-authenticode-trust"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "authenticode",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "psign-azure-kv-rest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "psign-codesigning-rest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "psign-digest-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "psign-opc-sign"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "psign-portable-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "authenticode",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "psign-portable-ffi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "psign-portable-core",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "psign-sip-digest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "authenticode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/Devolutions/psign"
 
 [package]
 name = "psign"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Rust port of the Windows SDK signtool.exe (Authenticode sign/verify/timestamp) with portable digest helpers."
 license.workspace = true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dotnet tool run psign-tool -- --help
 Create local dotnet tool packages from prebuilt release artifacts:
 
 ```powershell
-pwsh ./nuget/pack-psign-dotnet-tool.ps1 -Version 0.5.0 -ArtifactsRoot ./dist -OutputDir ./dist/nuget
+pwsh ./nuget/pack-psign-dotnet-tool.ps1 -Version 0.5.1 -ArtifactsRoot ./dist -OutputDir ./dist/nuget
 ```
 
 The package is built from native `psign-tool` artifacts for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`, plus an `any` fallback package for unsupported runtimes.

--- a/crates/psign-authenticode-trust/Cargo.toml
+++ b/crates/psign-authenticode-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-authenticode-trust"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Portable Authenticode PKCS#7 trust verification (anchors, chain, EKU) using picky-rs"
 license.workspace = true

--- a/crates/psign-azure-kv-rest/Cargo.toml
+++ b/crates/psign-azure-kv-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-azure-kv-rest"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Azure Key Vault certificate metadata + keys/sign REST (portable, blocking HTTP)"
 license.workspace = true

--- a/crates/psign-codesigning-rest/Cargo.toml
+++ b/crates/psign-codesigning-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-codesigning-rest"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Azure Code Signing data-plane CertificateProfileOperations Sign LRO (portable, blocking HTTP)"
 license.workspace = true

--- a/crates/psign-digest-cli/Cargo.toml
+++ b/crates/psign-digest-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-digest-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Linux/macOS-friendly CLI over portable Authenticode SIP digests (psign-sip-digest)"
 license.workspace = true

--- a/crates/psign-opc-sign/Cargo.toml
+++ b/crates/psign-opc-sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-opc-sign"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Portable OPC, VSIX, and NuGet package signing primitives"
 license.workspace = true

--- a/crates/psign-portable-core/Cargo.toml
+++ b/crates/psign-portable-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-portable-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Reusable portable Authenticode signing and inspection APIs for psign"
 license.workspace = true

--- a/crates/psign-portable-ffi/Cargo.toml
+++ b/crates/psign-portable-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-portable-ffi"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "C ABI shared library for psign portable Authenticode operations"
 license.workspace = true
@@ -20,4 +20,3 @@ anyhow = "1"
 psign-portable-core = { path = "../psign-portable-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-

--- a/crates/psign-sip-digest/Cargo.toml
+++ b/crates/psign-sip-digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-sip-digest"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Portable Authenticode SIP digest recomputation (PE, CAB, MSI, MSIX, scripts, …) without Win32"
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump the root psign package and workspace crate versions to 0.5.1
- Update Cargo.lock and release/package documentation examples for 0.5.1

## Validation
- cargo fmt --all
- cargo metadata --locked --format-version 1
- cargo test --workspace --locked --quiet
- cargo clippy --workspace --all-targets --locked --quiet