### PR TITLE
Update PowerShell module version bump

### DIFF
--- a/PowerShell/Devolutions.Psign/Devolutions.Psign.psd1
+++ b/PowerShell/Devolutions.Psign/Devolutions.Psign.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Devolutions.Psign.psm1'
-    ModuleVersion = '0.5.0'
+    ModuleVersion = '0.5.1'
     GUID = 'e6e50e4b-bf25-4ed6-a343-49f904e79f8f'
     Author = 'Devolutions'
     CompanyName = 'Devolutions'

--- a/nuget/tool/Devolutions.Psign.Tool.csproj
+++ b/nuget/tool/Devolutions.Psign.Tool.csproj
@@ -8,7 +8,7 @@
     <ToolCommandName>psign-tool</ToolCommandName>
     <PackageId>Devolutions.Psign.Tool</PackageId>
 
-    <Version Condition="'$(Version)' == ''">0.5.0</Version>
+    <Version Condition="'$(Version)' == ''">0.5.1</Version>
     <Authors>Devolutions</Authors>
     <Description>RID-specific dotnet tool wrapper around prebuilt psign-tool native executables.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -89,6 +89,75 @@ function Update-CargoPackageVersion {
         }
 }
 
+function Update-PowerShellModuleManifestVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if ($Version -notmatch '^(\d+\.\d+\.\d+)([-.](.+))?$') {
+        throw "Invalid PowerShell module version format: $Version"
+    }
+
+    $moduleVersion = $Matches[1]
+    $prerelease = $Matches[3]
+
+    Update-RequiredRegex `
+        -Path $Path `
+        -Pattern "(?m)^(\s*ModuleVersion\s*=\s*')([^']+)(')" `
+        -Description "PowerShell module version" `
+        -Replacement {
+            param($match)
+            "$($match.Groups[1].Value)$moduleVersion$($match.Groups[3].Value)"
+        }
+
+    $text = [System.IO.File]::ReadAllText($Path)
+    if ($prerelease) {
+        $prereleasePattern = "(?m)^(\s*Prerelease\s*=\s*')([^']*)(')"
+        if ([regex]::IsMatch($text, $prereleasePattern)) {
+            Update-RequiredRegex `
+                -Path $Path `
+                -Pattern $prereleasePattern `
+                -Description "PowerShell module prerelease" `
+                -Replacement {
+                    param($match)
+                    "$($match.Groups[1].Value)$prerelease$($match.Groups[3].Value)"
+                }
+            return
+        }
+
+        $regex = [regex]::new('(?m)^(\s*)PSData\s*=\s*@\{(\r?\n)')
+        $script:replaceCount = 0
+        $updated = $regex.Replace(
+            $text,
+            [System.Text.RegularExpressions.MatchEvaluator] {
+                param($match)
+                $script:replaceCount++
+                $indent = $match.Groups[1].Value
+                "$($indent)PSData = @{$($match.Groups[2].Value)$($indent)    Prerelease = '$prerelease'$($match.Groups[2].Value)"
+            },
+            1
+        )
+        $count = $script:replaceCount
+        $script:replaceCount = 0
+
+        if ($count -ne 1) {
+            throw "Expected exactly one PowerShell module PSData match in $Path; found $count."
+        }
+
+        Set-FileText -Path $Path -Text $updated
+        Write-Host "Added PowerShell module prerelease in $Path"
+        return
+    }
+
+    $regex = [regex]::new("(?m)^\s*Prerelease\s*=\s*'[^']*'\r?\n?")
+    $updated = $regex.Replace($text, '', 1)
+    if ($updated -ne $text) {
+        Set-FileText -Path $Path -Text $updated
+        Write-Host "Removed PowerShell module prerelease in $Path"
+    }
+}
+
 $cargoManifests = @((Join-Path $repoRoot "Cargo.toml"))
 $cratesRoot = Join-Path $repoRoot "crates"
 if (Test-Path -LiteralPath $cratesRoot) {
@@ -100,6 +169,9 @@ if (Test-Path -LiteralPath $cratesRoot) {
 foreach ($manifest in $cargoManifests) {
     Update-CargoPackageVersion -Path $manifest
 }
+
+$powerShellModuleManifest = Join-Path $repoRoot "PowerShell\Devolutions.Psign\Devolutions.Psign.psd1"
+Update-PowerShellModuleManifestVersion -Path $powerShellModuleManifest
 
 $toolProject = Join-Path $repoRoot "nuget\tool\Devolutions.Psign.Tool.csproj"
 Update-RequiredRegex `


### PR DESCRIPTION
## Summary
- update `scripts/bump-version.ps1` to bump the PowerShell module manifest version
- support PowerShell prerelease metadata when bumping prerelease versions
- align the checked-in PowerShell module and .NET tool fallback metadata with `0.5.1`

## Validation
- `./scripts/bump-version.ps1 -Version 0.5.1 -SkipCargoLock`
- prerelease round-trip: `0.5.1-beta.1` then back to `0.5.1`
- `git diff --check`