### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Release version to build/publish (for example 0.5.1)
+        description: Release version to build/publish (for example 0.6.0)
         required: true
         type: string
       publish_nuget:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "psign"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "psign-authenticode-trust"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "authenticode",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "psign-azure-kv-rest"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "psign-codesigning-rest"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "psign-digest-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "psign-opc-sign"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "psign-portable-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "authenticode",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "psign-portable-ffi"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "psign-portable-core",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "psign-sip-digest"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "authenticode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/Devolutions/psign"
 
 [package]
 name = "psign"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Rust port of the Windows SDK signtool.exe (Authenticode sign/verify/timestamp) with portable digest helpers."
 license.workspace = true

--- a/PowerShell/Devolutions.Psign/Devolutions.Psign.psd1
+++ b/PowerShell/Devolutions.Psign/Devolutions.Psign.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Devolutions.Psign.psm1'
-    ModuleVersion = '0.5.1'
+    ModuleVersion = '0.6.0'
     GUID = 'e6e50e4b-bf25-4ed6-a343-49f904e79f8f'
     Author = 'Devolutions'
     CompanyName = 'Devolutions'

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dotnet tool run psign-tool -- --help
 Create local dotnet tool packages from prebuilt release artifacts:
 
 ```powershell
-pwsh ./nuget/pack-psign-dotnet-tool.ps1 -Version 0.5.1 -ArtifactsRoot ./dist -OutputDir ./dist/nuget
+pwsh ./nuget/pack-psign-dotnet-tool.ps1 -Version 0.6.0 -ArtifactsRoot ./dist -OutputDir ./dist/nuget
 ```
 
 The package is built from native `psign-tool` artifacts for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`, plus an `any` fallback package for unsupported runtimes.

--- a/crates/psign-authenticode-trust/Cargo.toml
+++ b/crates/psign-authenticode-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-authenticode-trust"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Portable Authenticode PKCS#7 trust verification (anchors, chain, EKU) using picky-rs"
 license.workspace = true

--- a/crates/psign-azure-kv-rest/Cargo.toml
+++ b/crates/psign-azure-kv-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-azure-kv-rest"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Azure Key Vault certificate metadata + keys/sign REST (portable, blocking HTTP)"
 license.workspace = true

--- a/crates/psign-codesigning-rest/Cargo.toml
+++ b/crates/psign-codesigning-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-codesigning-rest"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Azure Code Signing data-plane CertificateProfileOperations Sign LRO (portable, blocking HTTP)"
 license.workspace = true

--- a/crates/psign-digest-cli/Cargo.toml
+++ b/crates/psign-digest-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-digest-cli"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Linux/macOS-friendly CLI over portable Authenticode SIP digests (psign-sip-digest)"
 license.workspace = true

--- a/crates/psign-opc-sign/Cargo.toml
+++ b/crates/psign-opc-sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-opc-sign"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Portable OPC, VSIX, and NuGet package signing primitives"
 license.workspace = true

--- a/crates/psign-portable-core/Cargo.toml
+++ b/crates/psign-portable-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-portable-core"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Reusable portable Authenticode signing and inspection APIs for psign"
 license.workspace = true

--- a/crates/psign-portable-ffi/Cargo.toml
+++ b/crates/psign-portable-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-portable-ffi"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "C ABI shared library for psign portable Authenticode operations"
 license.workspace = true

--- a/crates/psign-sip-digest/Cargo.toml
+++ b/crates/psign-sip-digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psign-sip-digest"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Portable Authenticode SIP digest recomputation (PE, CAB, MSI, MSIX, scripts, …) without Win32"
 license.workspace = true

--- a/nuget/tool/Devolutions.Psign.Tool.csproj
+++ b/nuget/tool/Devolutions.Psign.Tool.csproj
@@ -8,7 +8,7 @@
     <ToolCommandName>psign-tool</ToolCommandName>
     <PackageId>Devolutions.Psign.Tool</PackageId>
 
-    <Version Condition="'$(Version)' == ''">0.5.1</Version>
+    <Version Condition="'$(Version)' == ''">0.6.0</Version>
     <Authors>Devolutions</Authors>
     <Description>RID-specific dotnet tool wrapper around prebuilt psign-tool native executables.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Summary
- Bump all psign workspace crate versions from 0.5.1 to 0.6.0
- Update Cargo.lock package metadata for local crates
- Update NuGet tool, PowerShell module, README packaging example, and release workflow example versions

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked`
- `cargo metadata --format-version 1 --locked --quiet`
- `cargo test --workspace --locked --exclude psign`

Note: `cargo test --workspace --locked` reaches existing local WinVerifyTrust corpus failures with `0x800B010A` in `psign --test corpus_sign_verify`.